### PR TITLE
Normalize ForeignKey related_name declarations

### DIFF
--- a/src/api_service/models.py
+++ b/src/api_service/models.py
@@ -45,10 +45,20 @@ class ExperimentSource(models.Model):
     inference_experiments_as_mrna: QuerySet[InferenceExperiment]
     gem_source: QuerySet['Experiment']
     mrna_source: QuerySet['Experiment']
-    user_file = models.ForeignKey(UserFile, on_delete=models.CASCADE, blank=True, null=True,
-                                  related_name='user_file')
-    cgds_dataset: CGDSDataset = models.ForeignKey(CGDSDataset, on_delete=models.CASCADE, blank=True,
-                                                  null=True, related_name='cgds_dataset')
+    user_file = models.ForeignKey(
+        UserFile,
+        on_delete=models.CASCADE,
+        blank=True,
+        null=True,
+        related_name='experiment_sources_as_user_file'
+    )
+    cgds_dataset: CGDSDataset = models.ForeignKey(
+        CGDSDataset,
+        on_delete=models.CASCADE,
+        blank=True,
+        null=True,
+        related_name='experiment_sources_as_cgds_dataset'
+    )
 
     def get_valid_source(self) -> UserFile | CGDSDataset:
         """
@@ -134,8 +144,13 @@ class ExperimentClinicalSource(ExperimentSource):
     """
     inference_experiments: QuerySet[InferenceExperiment]
     clinical_source: QuerySet['Experiment']
-    extra_cgds_dataset: CGDSDataset = models.ForeignKey('datasets_synchronization.CGDSDataset',
-                                                        on_delete=models.CASCADE, blank=True, null=True)
+    extra_cgds_dataset: CGDSDataset = models.ForeignKey(
+        'datasets_synchronization.CGDSDataset',
+        on_delete=models.CASCADE,
+        blank=True,
+        null=True,
+        related_name='experiment_clinical_sources_as_extra_cgds_dataset'
+    )
 
     def get_methylation_platform_df(self):
         """
@@ -338,14 +353,23 @@ class Experiment(models.Model):
 
     name: str = models.CharField(max_length=100)
     description: Optional[str] = models.TextField(blank=True, null=True)
-    mRNA_source = models.ForeignKey('ExperimentSource', on_delete=models.CASCADE,
-                                    related_name='mrna_source')
-    gem_source: ExperimentSource = models.ForeignKey('ExperimentSource', on_delete=models.CASCADE,
-                                                     related_name='gem_source')
-    clinical_source: ExperimentClinicalSource = models.ForeignKey('api_service.ExperimentClinicalSource',
-                                                                  on_delete=models.SET_NULL,
-                                                                  related_name='clinical_source', blank=True,
-                                                                  null=True)
+    mRNA_source = models.ForeignKey(
+        'ExperimentSource',
+        on_delete=models.CASCADE,
+        related_name='experiments_as_mrna_source'
+    )
+    gem_source: ExperimentSource = models.ForeignKey(
+        'ExperimentSource',
+        on_delete=models.CASCADE,
+        related_name='experiments_as_gem_source'
+    )
+    clinical_source: ExperimentClinicalSource = models.ForeignKey(
+        'api_service.ExperimentClinicalSource',
+        on_delete=models.SET_NULL,
+        related_name='experiments_as_clinical_source',
+        blank=True,
+        null=True
+    )
     submit_date: datetime.datetime = models.DateTimeField(auto_now_add=True, blank=False, null=True)
     minimum_coefficient_threshold: float = models.FloatField(default=0.7)
     minimum_std_gene: float = models.FloatField(default=0.0)
@@ -423,12 +447,22 @@ class GeneGEMCombination(models.Model):
     id = models.BigAutoField(primary_key=True)
     # It's set as string foreign key to sort by Django Rest Framework
     # No DB constraint due to missing genes extra data
-    gene = models.ForeignKey(Gene, db_column='gene', on_delete=models.DO_NOTHING, db_constraint=False)
+    gene = models.ForeignKey(
+        Gene,
+        db_column='gene',
+        on_delete=models.DO_NOTHING,
+        db_constraint=False,
+        related_name='%(class)ss_as_gene'
+    )
     gem = models.CharField(max_length=50)
     correlation = models.FloatField()
     p_value = models.FloatField()
     adjusted_p_value = models.FloatField(blank=True, null=True)
-    experiment = models.ForeignKey(Experiment, on_delete=models.CASCADE)
+    experiment = models.ForeignKey(
+        Experiment,
+        on_delete=models.CASCADE,
+        related_name='%(class)ss'
+    )
 
     source_statistical_data = models.OneToOneField(
         'statistical_properties.SourceDataStatisticalProperties',

--- a/src/datasets_synchronization/models.py
+++ b/src/datasets_synchronization/models.py
@@ -250,42 +250,42 @@ class CGDSStudy(models.Model):
         on_delete=models.SET_NULL,
         blank=True,
         null=True,
-        related_name='mrna_dataset'
+        related_name='cgds_studies_as_mrna_dataset'
     )
     mirna_dataset = models.OneToOneField(
         CGDSDataset,
         on_delete=models.SET_NULL,
         blank=True,
         null=True,
-        related_name='mirna_dataset'
+        related_name='cgds_studies_as_mirna_dataset'
     )
     cna_dataset = models.OneToOneField(
         CGDSDataset,
         on_delete=models.SET_NULL,
         blank=True,
         null=True,
-        related_name='cna_dataset'
+        related_name='cgds_studies_as_cna_dataset'
     )
     methylation_dataset = models.OneToOneField(
         CGDSDataset,
         on_delete=models.SET_NULL,
         blank=True,
         null=True,
-        related_name='methylation_dataset'
+        related_name='cgds_studies_as_methylation_dataset'
     )
     clinical_patient_dataset = models.OneToOneField(
         CGDSDataset,
         on_delete=models.SET_NULL,
         blank=True,
         null=True,
-        related_name='clinical_patient_dataset'
+        related_name='cgds_studies_as_clinical_patient_dataset'
     )
     clinical_sample_dataset = models.OneToOneField(
         CGDSDataset,
         on_delete=models.SET_NULL,
         blank=True,
         null=True,
-        related_name='clinical_sample_dataset'
+        related_name='cgds_studies_as_clinical_sample_dataset'
     )
     task_id: Optional[str] = models.CharField(max_length=100, blank=True, null=True)  # Celery Task ID
 

--- a/src/statistical_properties/models.py
+++ b/src/statistical_properties/models.py
@@ -56,8 +56,16 @@ class SourceDataStatisticalProperties(models.Model):
     gem_mean = models.FloatField()
     gene_standard_deviation = models.FloatField()
     gem_standard_deviation = models.FloatField()
-    gene_normality = models.OneToOneField(NormalityTest, on_delete=models.CASCADE, related_name='gene_normality')
-    gem_normality = models.OneToOneField(NormalityTest, on_delete=models.CASCADE, related_name='gem_normality')
+    gene_normality = models.OneToOneField(
+        NormalityTest,
+        on_delete=models.CASCADE,
+        related_name='source_data_statistical_properties_as_gene_normality'
+    )
+    gem_normality = models.OneToOneField(
+        NormalityTest,
+        on_delete=models.CASCADE,
+        related_name='source_data_statistical_properties_as_gem_normality'
+    )
     heteroscedasticity_breusch_pagan = models.OneToOneField(BreuschPaganTest, on_delete=models.CASCADE)
     homoscedasticity_goldfeld_quandt = models.OneToOneField(GoldfeldQuandtTest, on_delete=models.CASCADE)
     linearity = models.OneToOneField(LinearityTest, on_delete=models.CASCADE, blank=True, null=True)
@@ -111,8 +119,13 @@ class StatisticalValidationSourceResult(models.Model):
     cox_log_likelihood = models.FloatField(null=True, blank=True)  # Log likelihood from Cox Regression (clustering)
     r2_score = models.FloatField(null=True, blank=True)  # R2 from regression models (SVM/RF)
     # Source
-    source = models.ForeignKey('api_service.ExperimentSource', on_delete=models.CASCADE, null=True, blank=True,
-                               related_name='statistical_validations_result')
+    source = models.ForeignKey(
+        'api_service.ExperimentSource',
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name='statistical_validation_source_results'
+    )
 
     @property
     def number_of_rows(self) -> int:


### PR DESCRIPTION
## Summary
- fix ExperimentSource reverse relationships for file and CGDS dataset sources
- standardize Experiment and GeneGEMCombination reverse accessors
- clarify statistical and synchronization models' ForeignKey related_name values

## Testing
- `venv/bin/python src/manage.py makemigrations` *(fails: ModuleNotFoundError: No module named 'channels')*
- `venv/bin/python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5a0fc9c4c8324be14a185bd023d2e